### PR TITLE
Fix reverse motions the have different signs of v0 and v1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calc_intervals_should_get_same_result_for_opposite_directions() {
+    fn calc_intervals_should_get_same_result_for_opposite_directions() {
         let constraints = SCurveConstraints {
             max_jerk: 3.,
             max_acceleration: 2.0,
@@ -1179,7 +1179,7 @@ mod tests {
     }
 
     #[test]
-    fn test_calc_intervals_should_get_same_result_for_opposite_directions_vmax_not_reached() {
+    fn calc_intervals_should_get_same_result_for_opposite_directions_vmax_not_reached() {
         let constraints = SCurveConstraints {
             max_jerk: 3.,
             max_acceleration: 2.0,
@@ -1214,5 +1214,47 @@ mod tests {
         assert!(times.t_v == times_2.t_v);
         assert!(times.t_j2 == times_2.t_j2);
         assert!(times.t_d == times_2.t_d);
+    }
+
+    #[test]
+    fn is_trajectory_feasible_basic() {
+        let constraints = SCurveConstraints {
+            max_jerk: 3.,
+            max_acceleration: 2.0,
+            max_velocity: 3.,
+        };
+        let start_conditions = SCurveStartConditions {
+            q0: 0.,
+            q1: 10.,
+            v0: 1.,
+            v1: 0.,
+        };
+        let input = SCurveInput {
+            constraints,
+            start_conditions,
+        };
+
+        assert!(input.is_trajectory_feasible());
+    }
+
+    #[test]
+    fn is_trajectory_feasible_v_max_not_reached() {
+        let constraints = SCurveConstraints {
+            max_jerk: 3.,
+            max_acceleration: 2.0,
+            max_velocity: 3.,
+        };
+        let start_conditions = SCurveStartConditions {
+            q0: 0.,
+            q1: 4.,
+            v0: 1.,
+            v1: 0.,
+        };
+        let input = SCurveInput {
+            constraints,
+            start_conditions,
+        };
+
+        assert!(input.is_trajectory_feasible());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1153,7 +1153,7 @@ mod tests {
             q1: 10.,
             v0: -1.,
             v1: 2.,
-        };       
+        };
         let start_conditions_2 = SCurveStartConditions {
             q0: 0.,
             q1: -10.,
@@ -1176,7 +1176,6 @@ mod tests {
         assert!(times.t_v == times_2.t_v);
         assert!(times.t_j2 == times_2.t_j2);
         assert!(times.t_d == times_2.t_d);
-
     }
 
     #[test]
@@ -1192,7 +1191,7 @@ mod tests {
             q1: 5.,
             v0: -1.,
             v1: 2.,
-        };  
+        };
         let start_conditions_2 = SCurveStartConditions {
             q0: 0.,
             q1: -5.,
@@ -1215,6 +1214,5 @@ mod tests {
         assert!(times.t_v == times_2.t_v);
         assert!(times.t_j2 == times_2.t_j2);
         assert!(times.t_d == times_2.t_d);
-
     }
 }


### PR DESCRIPTION
Currently, the calculation of a reverse motion may get the wrong result when the signs of ``v0`` and ``v1`` are different. For example, consider an input:
```rust
    let constraints = SCurveConstraints {
        max_jerk: 3.,
        max_acceleration: 2.0,
        max_velocity: 3.,
    };
    let start_conditions = SCurveStartConditions {
        q0: 0.,
        q1: 10.,
        v0: -1.,
        v1: 2.,
    };
    let input = SCurveInput {
        constraints,
        start_conditions,
    };
```
And the result profile will be like:
![image](https://github.com/marcbone/s_curve/assets/21167892/d9371a66-9446-4f4d-8781-01835d334643)

But when a reverse version of the above input is calculated:
```rust
    let constraints = SCurveConstraints {
        max_jerk: 3.,
        max_acceleration: 2.0,
        max_velocity: 3.,
    };
    let start_conditions = SCurveStartConditions {
        q0: 0.,
        q1: -10.,
        v0: 1.,
        v1: -2.,
    };
    let input = SCurveInput {
        constraints,
        start_conditions,
    };
```
The result profile will be like:
![image](https://github.com/marcbone/s_curve/assets/21167892/8f1f9f6b-6f92-47dd-9c6c-23452eb6b4d5)

After the modification, the result profile will be like the reverse version of the original profile, as expected:
![image](https://github.com/marcbone/s_curve/assets/21167892/18096170-70b7-4961-a72f-ebe52beb5e49)

Two test cases are added as well to confirm that two opposite start conditions will get the same time intervals.